### PR TITLE
fix: use --databases env var

### DIFF
--- a/mysql-mariadb/alpine-periodic-backup/scripts/daily/database-backup
+++ b/mysql-mariadb/alpine-periodic-backup/scripts/daily/database-backup
@@ -15,4 +15,4 @@ MUSER="root"
 [ ! -d "$BACKUP_FOLDER" ] && mkdir -p "$BACKUP_FOLDER"
 
 FILE=$BACKUP_FOLDER/backup-$NOW.sql.gz
-$MYSQLDUMP -h $MHOST -u $MUSER -p$MPASS $MDB | $GZIP -9 > $FILE
+$MYSQLDUMP -h $MHOST -u $MUSER -p$MPASS --databases $MDB | $GZIP -9 > $FILE 


### PR DESCRIPTION
Previously did not export the database as default database.